### PR TITLE
Implementation notes

### DIFF
--- a/draft-selander-lake-authz.md
+++ b/draft-selander-lake-authz.md
@@ -124,7 +124,7 @@ The (domain) authenticator may represent the service provider or some other part
 The protocol assumes that authentication between device and authenticator is performed with EDHOC {{I-D.ietf-lake-edhoc}}, and defines the integration of a lightweight authorization procedure using the External Authorization Data (EAD) fields defined in EDHOC.
 
 Implementations wishing to leverage the zero-touch capabilities of this protocol are expected to support transmission of credentials by value during the EDHOC exchange.
-Impacts on message size will depend on the type of credential used, e.g., the credentials in {{I-D.ietf-lake-traces}} are CWT Claim Sets of 95 bytes long.
+Impacts on message size will depend on the type of credential used.
 
 The protocol enables a low message count by performing authorization and enrollment in parallel with authentication, instead of in sequence which is common for network access.
 It further reuses protocol elements from EDHOC leading to reduced message sizes on constrained links.

--- a/draft-selander-lake-authz.md
+++ b/draft-selander-lake-authz.md
@@ -123,9 +123,6 @@ The (domain) authenticator may represent the service provider or some other part
 
 The protocol assumes that authentication between device and authenticator is performed with EDHOC {{I-D.ietf-lake-edhoc}}, and defines the integration of a lightweight authorization procedure using the External Authorization Data (EAD) fields defined in EDHOC.
 
-Implementations wishing to leverage the zero-touch capabilities of this protocol are expected to support transmission of credentials by value during the EDHOC exchange.
-Impacts on message size will depend on the type of credential used.
-
 The protocol enables a low message count by performing authorization and enrollment in parallel with authentication, instead of in sequence which is common for network access.
 It further reuses protocol elements from EDHOC leading to reduced message sizes on constrained links.
 
@@ -177,7 +174,9 @@ The protocol is based on the following pre-existing relations between the device
 * V and W have an implicit relation, e.g., based on web PKI with trusted CA certificates, see {{domain-auth}}.
 * U and V need not have any previous relation, this protocol establishes a relation between U and V.
 
-Each of the three parties have protected communication with the other two during the protocol.
+Each of the three parties can gain protected communication with the other two during the protocol.
+
+V may be able to access credentials over non-nonstrained networks, but U may be limited to constrained networks. Implementations wishing to leverage the zero-touch capabilities of this protocol are expected to support transmission of credentials from V to U by value during the EDHOC exchange, which will impact the message size depending on type of credential used.
 
 ~~~~~~~~~~~ aasvg
 
@@ -189,7 +188,7 @@ Each of the three parties have protected communication with the other two during
 |          |            |               |            |               |
 |  Device  |    con-    |    Domain     |  not con-  |   Enrollment  |
 |          |  strained  | Authenticator |  strained  |     Server    |
-|   (U)    |  network   |       (V)     |  network   |      (W)      |
+|   (U)    |  network   |      (V)      |  network   |      (W)      |
 |          |            |               |            |               |
 +----+-----+            +-------+-------+            +-------+-------+
      |                          |                            |
@@ -198,6 +197,7 @@ Each of the three parties have protected communication with the other two during
                                     (e.g., web PKI based)
 ~~~~~~~~~~~
 {: #fig-trust title="Overview of pre-existing relations." artwork-align="center"}
+
 
 
 ## Device (U) {#device}

--- a/draft-selander-lake-authz.md
+++ b/draft-selander-lake-authz.md
@@ -52,6 +52,7 @@ normative:
   RFC8949:
   RFC9052:
   RFC8613:
+  RFC8152:
   I-D.ietf-lake-edhoc:
   NIST-800-56A:
     author:

--- a/draft-selander-lake-authz.md
+++ b/draft-selander-lake-authz.md
@@ -412,6 +412,8 @@ where
 
 * SS is the selected cipher suite in SUITES_I of EDHOC message_1, see {{U-V}}.
 
+The external_aad is wrapped in an enc_structure as defined in {{Section 5.3 of RFC8152}}.
+
 Editor's note: Add more context to external_aad.
 
 The derivation of K_1 = EDHOC-Expand(PRK, info, length) uses the following input to the info struct (see {{reuse}}):

--- a/draft-selander-lake-authz.md
+++ b/draft-selander-lake-authz.md
@@ -86,6 +86,7 @@ informative:
   RFC8995:
   RFC9031:
   I-D.ietf-core-oscore-edhoc:
+  I-D.ietf-lake-traces:
   I-D.ietf-lake-reqs:
   IEEE802.15.4:
     title: "IEEE Std 802.15.4 Standard for Low-Rate Wireless Networks"
@@ -121,6 +122,9 @@ The enrollment server may represent the manufacturer of the device, or some othe
 The (domain) authenticator may represent the service provider or some other party controlling access to the network in which the device is enrolling.
 
 The protocol assumes that authentication between device and authenticator is performed with EDHOC {{I-D.ietf-lake-edhoc}}, and defines the integration of a lightweight authorization procedure using the External Authorization Data (EAD) fields defined in EDHOC.
+
+Implementations wishing to leverage the zero-touch capabilities of this protocol are expected to support transmission of credentials by value during the EDHOC exchange.
+Impacts on message size will depend on the type of credential used, e.g., the credentials in {{I-D.ietf-lake-traces}} are CWT Claim Sets of 95 bytes long.
 
 The protocol enables a low message count by performing authorization and enrollment in parallel with authentication, instead of in sequence which is common for network access.
 It further reuses protocol elements from EDHOC leading to reduced message sizes on constrained links.

--- a/draft-selander-lake-authz.md
+++ b/draft-selander-lake-authz.md
@@ -395,7 +395,7 @@ where
 
 ENC_ID is 'ciphertext' of COSE_Encrypt0 ({{Section 5.2 of RFC9052}}) computed from the following:
 
-* The encryption key K_1 and nonce IV_1 are derived as specified below.
+* The encryption key K_1 and nonce IV_1 are derived as specified below (see OKM in {{reuse}}).
 * 'protected' is a byte string of size 0
 * 'plaintext' and 'external_aad' as below:
 

--- a/draft-selander-lake-authz.md
+++ b/draft-selander-lake-authz.md
@@ -395,7 +395,7 @@ where
 
 ENC_ID is 'ciphertext' of COSE_Encrypt0 ({{Section 5.2 of RFC9052}}) computed from the following:
 
-* The encryption key K_1 and nonce IV_1 are derived as specified below (see OKM in {{reuse}}).
+* The encryption key K_1 and nonce IV_1 are derived as specified below.
 * 'protected' is a byte string of size 0
 * 'plaintext' and 'external_aad' as below:
 
@@ -420,13 +420,13 @@ The external_aad is wrapped in an enc_structure as defined in {{Section 5.3 of R
 
 Editor's note: Add more context to external_aad.
 
-The derivation of K_1 = EDHOC-Expand(PRK, info, length) uses the following input to the info struct (see {{reuse}}):
+The derivation of K_1 = EDHOC-Expand(PRK, info, length) uses the following input to the info struct (see OKM in {{reuse}}):
 
 * info_label = 0
 * context  = h'' (the empty CBOR string)
 * length is length of key of the EDHOC AEAD algorithm in bytes (which is the length of K_1)
 
-The derivation of IV_1 = EDHOC-Expand(PRK, info, length) uses the following input to the info struct (see {{reuse}}):
+The derivation of IV_1 = EDHOC-Expand(PRK, info, length) uses the following input to the info struct (see OKM in {{reuse}}):
 
 * info_label = 1
 * context = h''  (the empty CBOR string)

--- a/draft-selander-lake-authz.md
+++ b/draft-selander-lake-authz.md
@@ -424,13 +424,13 @@ The derivation of K_1 = EDHOC-Expand(PRK, info, length) uses the following input
 
 * info_label = 0
 * context  = h'' (the empty CBOR string)
-* length is length of key of the EDHOC AEAD algorithm in bytes
+* length is length of key of the EDHOC AEAD algorithm in bytes (which is the length of K_1)
 
 The derivation of IV_1 = EDHOC-Expand(PRK, info, length) uses the following input to the info struct (see {{reuse}}):
 
 * info_label = 1
 * context = h''  (the empty CBOR string)
-* length is length of nonce of the EDHOC AEAD algorithm in bytes
+* length is length of nonce of the EDHOC AEAD algorithm in bytes (which is the length of IV_1)
 
 ### Voucher {#voucher}
 


### PR DESCRIPTION
There are 3 clarifications in separate commits. I am not totally sure if the consideration about credentials by value should be in the introduction, but I wanted them to be upfront in the document since it is a requirement to EDHOC implementations who wish to support this.