### PR TITLE
CoJP examples: Don't send extra Content-Format

### DIFF
--- a/draft-ietf-lake-authz.md
+++ b/draft-ietf-lake-authz.md
@@ -869,7 +869,6 @@ The device SHALL map the message to a CoAP request:
 * The Proxy-Scheme option is set to "coap".
 * The Uri-Host option is set to "lake-authz.arpa". This is an anycast type of identifier of the domain authenticator (V) that is resolved to its IPv6 address by the Join Proxy.
 * The Uri-Path option is set to ".well-known/edhoc".
-* The Content-Format option is set to "application/cid-edhoc+cbor-seq"
 * The payload is the (true, EDHOC message_1) CBOR sequence, where EDHOC message_1 is constructed as defined in {{U-V}}.
 
 ### Flight 2
@@ -880,7 +879,6 @@ If the exchange between V and W completes successfully, the domain authenticator
 The authenticator SHALL map the message to a CoAP response:
 
 * The response code is 2.04 Changed.
-* The Content-Format option is set to "application/edhoc+cbor-seq"
 * The payload is the EDHOC message_2, as defined in {{U-V}}.
 
 ### Flight 3


### PR DESCRIPTION
Sending these is optional in oscore-edhoc, and given there is a SHALL in the text, this needlessly increases the verbosity over the air.

(I'm tempted to state something similar about the CON in message 1, especially with regard to RFC9031's text on join proxies, but at least that's more complicated, and removing content-format is easy).