### PR TITLE
Fix contact for media type registration

### DIFF
--- a/draft-ietf-lake-authz.md
+++ b/draft-ietf-lake-authz.md
@@ -830,10 +830,10 @@ IANA has added the media types "application/lake-authz-voucherrequest+cbor" to t
     * Magic number(s): N/A
     * File extension(s): N/A
     * Macintosh file type code(s): N/A
-* Person & email address to contact for further information: See "Authors' Addresses" section.
+* Person & email address to contact for further information: IETF LAKE Working Group (lake@ietf.org)
 * Intended usage: COMMON
 * Restrictions on usage: N/A
-* Author: See "Authors' Addresses" section.
+* Author: LAKE WG
 * Change Controller: IESG
 
 ## CoAP Content-Formats Registry


### PR DESCRIPTION
Solves #35.

I consulted some existing recent RFCs and apparently the most common approach is to refer to a WG or area. 
I decided to just link the WG.
Below are some examples.
```
- some use WG name, e.g. in RFCs 9553, 8949: "IETF CBOR Working Group (cbor@ietf.org) or IETF Applications and Real-Time Area (art@ietf.org)"
- some use the IESG, e.g. in RFC 9525: "iesg@ietf.org"
- some use just Author's Addresses with RFC name, e.g. in RFC 9528: "See "Authors' Addresses" section in RFC 9528."
```