### PR TITLE
No need for DTLS client auth when DTLS+EDHOC used for PoP

### DIFF
--- a/draft-ietf-lake-authz.md
+++ b/draft-ietf-lake-authz.md
@@ -237,7 +237,7 @@ Some of the possible combinations of protocols to secure the connection between 
 | Secure channel between V and W | Proof-of-Possession from V to W | Type of CRED_V | EDHOC method used by V |
 |--|--|--|--|
 | [D]TLS 1.3 with mutual authentication, where V is the client and W is the server. | Provided by [D]TLS. | Restricted to types that are supported by both [D]TLS and EDHOC, e.g., X.509 certificates. | V MUST authenticate using a signature. |
-| [D]TLS 1.3 with client authentication, where V is the client and W is the server. | Run an EDHOC session on top of the TLS-protected channel. | Any type supported by EDHOC, e.g., X.509, C509, CWT, or CCS. | Any method may be used. |
+| [D]TLS 1.3, where V is the client and W is the server. | Run an EDHOC session on top of the TLS-protected channel. | Any type supported by EDHOC, e.g., X.509, C509, CWT, or CCS. | Any method may be used. |
 | EDHOC and OSCORE, where V is the initiator and W is the responder.    | Already provided by EDHOC during the setup of the secure channel. | Any type supported by EDHOC. | Any method may be used. |
 {: #creds-table title="Examples of how to secure the connection between V and W." cols="l l l"}
 


### PR DESCRIPTION
Fixing an issue raised by Marco Tiloca during the last IETF meeting.

Rationale: client authentication is not needed for DTLS in the case that EDHOC is used for PoP.