### PR TITLE
Add note for IANA regarding preferred value range of EAD labels

### DIFF
--- a/draft-ietf-lake-authz.md
+++ b/draft-ietf-lake-authz.md
@@ -983,6 +983,8 @@ The ead_label = TBD1 corresponds to the ead_value = Voucher_Info, which can be c
 
 The ead_label = TBD2 corresponds to ead_value = Voucher, and can be carried in either EAD_2 or EAD_3, see {{reverse-u-responder}}.
 
+Note for IANA reviewers: the preferred value range is 0-23 (Standards Action with Expert Review).
+
 ## The Well-Known URI Registry
 
 IANA has registered the following entry in "The Well-Known URI Registry", using the template from {{RFC8615}}:


### PR DESCRIPTION
Fixes #52, addresses comment in #51.

@gselander, I am not sure if the correct procedure is to specify concrete EAD labels now, directly in the draft.

Nevertheless, I checked the [IANA EDHOC External Authorization Data Registry](https://www.iana.org/assignments/edhoc/edhoc.xhtml#edhoc-ead) and the next available label is 1, so I am proposing to use 1 and 2 for Voucher_Info and Voucher, respectively. 

Please let me know whether this is the right way to proceed or some adjustment is needed.