### PR TITLE
Addressing IANA review comments

### DIFF
--- a/draft-ietf-lake-authz.md
+++ b/draft-ietf-lake-authz.md
@@ -1024,7 +1024,7 @@ IANA has added the media types "application/lake-authz-voucherrequest+cbor" to t
 * Intended usage: COMMON
 * Restrictions on usage: N/A
 * Author: LAKE WG
-* Change Controller: IESG
+* Change Controller: IETF
 
 ## CoAP Content-Formats Registry
 

--- a/draft-ietf-lake-authz.md
+++ b/draft-ietf-lake-authz.md
@@ -990,6 +990,7 @@ IANA has registered the following entry in "The Well-Known URI Registry", using 
 * URI suffix: lake-authz
 * Change controller: IETF
 * Specification document: \[\[this document\]\]
+* Status: permanent
 * Related information: None
 
 ## Well-Known Name Under ".arpa" Name Space

--- a/draft-ietf-lake-authz.md
+++ b/draft-ietf-lake-authz.md
@@ -1031,8 +1031,10 @@ IANA has added the media types "application/lake-authz-voucherrequest+cbor" to t
 IANA has added the following Content-Format number in the "CoAP Content-Formats" registry under the registry group "Constrained RESTful Environments (CoRE) Parameters".
 
 | Content Type | Content Encoding | ID | Reference |
-| application/lake-authz-voucherrequest+cbor | - | TBD2 | [[this document]] |
+| application/lake-authz-voucherrequest+cbor | - | TBD3 | [[this document]] |
 {: #coap-content-formats title="Addition to the CoAP Content-Formats registry" cols="l l l"}
+
+Note for IANA reviewers: the preferred value range is 0-255 (Expert Review).
 
 --- back
 


### PR DESCRIPTION
Address comments from #51:


1) :heavy_check_mark:  :arrow_right:  addressed in PR #54 

2) :heavy_check_mark:  Section 7.2: Please add the “Status” field for the Well-Known URI.

3) :warning: [under discussion in #51]  Section 7.3: Please add the “Domain Name Reservation Considerations” subsection

4) :heavy_check_mark:  Section 7.4: Please replace the IESG with the IETF in the media type’s change controller field.

5) :heavy_check_mark:  Section 7.5: Please specify a preferred value range the CoAP Content-Format registration. 
